### PR TITLE
mksecret: Fix compilation problems

### DIFF
--- a/mksecret/mksecret.ino
+++ b/mksecret/mksecret.ino
@@ -86,7 +86,8 @@ void loop () {
 
 void hexdump(byte* string, int size) {
   for (int i = 0; i < size; i++) {
-    Serial.print(string[i] >> 4, HEX);
-    Serial.print(string[i] & 0xF, HEX);
+    char buf[3] = {0};
+    snprintf(buf, sizeof(buf), "%x%x", string[i] >> 4, string[i] & 0xF);
+    Serial.print(buf);
   }
 }

--- a/mksecret/mksecret.ino
+++ b/mksecret/mksecret.ino
@@ -33,8 +33,6 @@
 OneWire ds(PIN_1WIRE);
 DS1961  sha(&ds);
 
-byte addr[8];
-
 void led (byte color) {
   digitalWrite(PIN_LED_GREEN, color & GREEN);
   digitalWrite(PIN_LED_RED,   color & RED);
@@ -45,44 +43,45 @@ void setup () {
   Serial.println("RESET");
   pinMode(PIN_LED_GREEN, OUTPUT);
   pinMode(PIN_LED_RED,   OUTPUT);
-  Entropy.Initialize();
+  pinMode(A0,            INPUT);
+  pinMode(A1,            INPUT);
+  pinMode(A2,            INPUT);
 }
 
 void loop () {
-  
-  byte secret[8];
-  int i;
-  
-  for (i = 0; i < 8; i++) {
-    secret[i] = Entropy.random(256);
-  }
-  
-  while (1) { /* yo dawg */
-  
-    ds.reset_search();
-    if (ds.search(addr)) {
-      if (OneWire::crc8(addr, 7) != addr[7]) return;
-      delay(100);
-      hexdump(addr, 8);
-      Serial.print(":");
-  
-      if (!sha.WriteSecret(addr, secret)) {
-        Serial.println("ERROR");
-        led(RED);
-      } else {
-        hexdump(secret, 8);
-        Serial.println("");
-        led(GREEN);
-      }
-      delay(5000);
-      
-      break;
+  ds.reset_search();
+  byte addr[8];
+  if (ds.search(addr)) {
+    if (OneWire::crc8(addr, 7) != addr[7]) return;
+
+    unsigned long rseed = millis();
+    for (int i = 0; i < 7; i++) {
+      rseed ^= analogRead(A0) | analogRead(A1)<<10 | analogRead(A2)<<20;
+      delay(1);
     }
-    
-    led( millis() % 150 > 120 ? OFF : RED
-    );
+    randomSeed(rseed);
+    byte secret[8];
+    for (int i = 0; i < 8; i++) {
+      secret[i] = random(256);
+    }
+
+    delay(100);
+    hexdump(addr, 8);
+    Serial.print(":");
+    if (!sha.WriteSecret(addr, secret)) {
+      Serial.println("ERROR");
+      led(RED);
+    } else {
+      hexdump(secret, 8);
+      Serial.println("");
+      led(GREEN);
+    }
+    delay(5000);
+
+    return;
   }
 
+  led(millis() % 150 > 120 ? OFF : RED);
 }
 
 void hexdump(byte* string, int size) {


### PR DESCRIPTION
Compilation of mksecret was not possible due to a missing entropy library. After repeated attempts to find the right version of this library, we gave up and just used Arduino's pseudorandom generator with some environment factors thrown in. :c

Also, the hex output is now in lowercase. The reason why I reflashed our programmer in the first place.
